### PR TITLE
[codex] Build static tailscaled release binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,8 +57,13 @@ jobs:
           GIT_COMMIT_SHORT="${GIT_COMMIT:0:9}"
           VERSION_LONG="${VERSION_SHORT}-t${GIT_COMMIT_SHORT}"
           LDFLAGS="-s -w -X tailscale.com/version.longStamp=${VERSION_LONG} -X tailscale.com/version.shortStamp=${VERSION_SHORT} -X tailscale.com/version.gitCommitStamp=${GIT_COMMIT}"
-          GOARCH=amd64 GOOS=linux go build -trimpath -ldflags="$LDFLAGS" -o tailscaled-linux-amd64 ./cmd/tailscaled
-          GOARCH=arm64 GOOS=linux go build -trimpath -ldflags="$LDFLAGS" -o tailscaled-linux-arm64 ./cmd/tailscaled
+          CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -trimpath -ldflags="$LDFLAGS" -o tailscaled-linux-amd64 ./cmd/tailscaled
+          CGO_ENABLED=0 GOARCH=arm64 GOOS=linux go build -trimpath -ldflags="$LDFLAGS" -o tailscaled-linux-arm64 ./cmd/tailscaled
+
+          go version -m tailscaled-linux-amd64 | tee tailscaled-linux-amd64.buildinfo
+          go version -m tailscaled-linux-arm64 | tee tailscaled-linux-arm64.buildinfo
+          grep -q 'CGO_ENABLED=0' tailscaled-linux-amd64.buildinfo
+          grep -q 'CGO_ENABLED=0' tailscaled-linux-arm64.buildinfo
 
       - name: Upload assets to release
         env:


### PR DESCRIPTION
## Summary

- Force `CGO_ENABLED=0` for both Linux amd64 and arm64 `tailscaled` release binaries.
- Print and assert Go build metadata so the release job fails if either binary is built with cgo enabled.

## Why

The release workflow runs on an amd64 Ubuntu runner. Without an explicit cgo setting, the amd64 build is native and gets `CGO_ENABLED=1`, producing a glibc-linked binary, while the arm64 cross-build gets `CGO_ENABLED=0` and is static. The Kubernetes private-node bundle renames this binary to `vcluster-tunnel`, and the dynamic amd64 artifact cannot run in musl-based upgrade pods.

## Validation

- `CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -trimpath -ldflags='-s -w' -o /tmp/tailscale-release-verify/tailscaled-linux-amd64 ./cmd/tailscaled`
- `CGO_ENABLED=0 GOARCH=arm64 GOOS=linux go build -trimpath -ldflags='-s -w' -o /tmp/tailscale-release-verify/tailscaled-linux-arm64 ./cmd/tailscaled`
- `file /tmp/tailscale-release-verify/tailscaled-linux-amd64 /tmp/tailscale-release-verify/tailscaled-linux-arm64` reported both artifacts as statically linked.
- `go version -m` reported `CGO_ENABLED=0` for both artifacts.
- `git diff --check`